### PR TITLE
Compatibility fixes for NumPy >= 1.24 and SciPy >= 1.13 (+ log-noise cleanup)

### DIFF
--- a/dr/binning.py
+++ b/dr/binning.py
@@ -832,7 +832,7 @@ def prescribed_bin_sami(hdu,sectors=8,radial=5,log=False,
 
     #Shift and rotate the spaxel coordinates so that the galaxy centre
     #is at (0,0) and the major axis is aligned with the x axis
-    spax_pos = np.indices(np.shape(image),dtype=np.float)
+    spax_pos = np.indices(np.shape(image),dtype=float)  # float removed in numpy 1.24
     spax_pos[0,:] = spax_pos[0,:] - round(xmed)
     spax_pos[1,:] = spax_pos[1,:] - round(ymed)
     spax_pos_rot = np.zeros(np.shape(spax_pos))
@@ -922,7 +922,7 @@ def aperture_bin_sami(hdu, aperture_radius=1, ellipticity=0, pa=0):
     # galaxy, i.e., distance from the major axis in the first coordinate and
     # distance from the minor axis in the second coordinate
 
-    spax_pos = np.indices((n_spax, n_spax), dtype=np.float)
+    spax_pos = np.indices((n_spax, n_spax), dtype=float)  # float removed in numpy 1.24
     # Shift centre to be centre of cube.
     spax_pos[0, :] = spax_pos[0, :, :] - xmed
     spax_pos[1, :] = spax_pos[1, :, :] - ymed

--- a/dr/cvd_model.py
+++ b/dr/cvd_model.py
@@ -931,8 +931,8 @@ def get_chunks(ifu, n_drop=None, n_chunk=None, sigma_clip=None):
     else:
         data = ifu.data
     # Convert to integer for future compatibility.
-    n_chunk = np.int(np.floor(n_chunk))
-    chunk_size = np.int(np.floor(chunk_size))
+    n_chunk = int(np.floor(n_chunk))  # int removed in numpy 1.24
+    chunk_size = int(np.floor(chunk_size))
     start = n_drop
     end = n_drop + n_chunk * chunk_size
     data = data[:, start:end].reshape(n_fibre, n_chunk, chunk_size)
@@ -958,8 +958,8 @@ def chunk_again(chunked_data_i, islice, n_drop=None, n_chunk=None, sigma_clip=No
     chunk_size = round((n_pixel - 2*n_drop) / n_chunk)
 
     # Convert to integer for future compatibility.
-    n_chunk = np.int(np.floor(n_chunk))
-    chunk_size = np.int(np.floor(chunk_size))
+    n_chunk = int(np.floor(n_chunk))  # int removed in numpy 1.24
+    chunk_size = int(np.floor(chunk_size))
     start = n_drop
     end = n_drop + n_chunk * chunk_size
     data = data[:, start:end].reshape(n_fibre, n_chunk, chunk_size)
@@ -1302,7 +1302,7 @@ def parameters_dict_to_vector(parameters_dict, model_name):
 def parameters_vector_to_dict(parameters_vector, model_name):
     """Convert a parameters vector to a dictionary."""
     parameters_dict = {}
-    n_slice = np.int((len(parameters_vector) - 10) // 3)
+    n_slice = int((len(parameters_vector) - 10) // 3)
     parameters_dict['flux'] = parameters_vector[0:n_slice]
     parameters_dict['background'] = parameters_vector[n_slice:2*n_slice]
     parameters_dict['wavelength'] = parameters_vector[2*n_slice:3*n_slice]

--- a/dr/voronoi_2d_binning_wcovar.py
+++ b/dr/voronoi_2d_binning_wcovar.py
@@ -131,8 +131,8 @@ def guess_regular_grid(xnodes, ynodes, pixelsize=None) :
     xn_rav, yn_rav = xnodes.ravel(), ynodes.ravel()
     if pixelsize == None :
         pixelsize = derive_pixelsize(xnodes, ynodes)
-    minxn = np.int(np.min(xn_rav) / pixelsize) * pixelsize
-    minyn = np.int(np.min(yn_rav) / pixelsize) * pixelsize
+    minxn = int(np.min(xn_rav) / pixelsize) * pixelsize  # int removed in numpy 1.24
+    minyn = int(np.min(yn_rav) / pixelsize) * pixelsize
     xunb, yunb = np.meshgrid(np.arange(minxn, np.max(xn_rav)+pixelsize, pixelsize), 
                            np.arange(minyn, np.max(yn_rav)+pixelsize, pixelsize))
 

--- a/general/covar.py
+++ b/general/covar.py
@@ -20,8 +20,8 @@ def create_covar_matrix_original(overlap_array,variances):
         return covariance_array
     
     #Set up coordinate arrays for the covariance sub-arrays
-    xB = np.zeros(((covarS*2+1)**2),dtype=np.int)
-    yB = np.zeros(((covarS*2+1)**2),dtype=np.int)
+    xB = np.zeros(((covarS*2+1)**2),dtype=int)
+    yB = np.zeros(((covarS*2+1)**2),dtype=int)
     for i in range(covarS*2+1):
         for j in range(covarS*2+1):
             xB[j+i*(covarS*2+1)] = i
@@ -86,8 +86,8 @@ def create_covar_matrix_vectorised(overlap_array,variances):
         return covariance_array
     
     #Set up coordinate arrays for the covariance sub-arrays
-    xB = np.zeros(((covarS*2+1)**2),dtype=np.int)
-    yB = np.zeros(((covarS*2+1)**2),dtype=np.int)
+    xB = np.zeros(((covarS*2+1)**2),dtype=int)
+    yB = np.zeros(((covarS*2+1)**2),dtype=int)
     for i in range(covarS*2+1):
         for j in range(covarS*2+1):
             xB[j+i*(covarS*2+1)] = i
@@ -166,8 +166,8 @@ def create_covar_matrix_newest(overlap_array,variances):
         return covariance_array
     
     #Set up coordinate arrays for the covariance sub-arrays
-    xB = np.zeros(((covarS*2+1)**2),dtype=np.int)
-    yB = np.zeros(((covarS*2+1)**2),dtype=np.int)
+    xB = np.zeros(((covarS*2+1)**2),dtype=int)
+    yB = np.zeros(((covarS*2+1)**2),dtype=int)
     for i in range(covarS*2+1):
         for j in range(covarS*2+1):
             xB[j+i*(covarS*2+1)] = i
@@ -183,8 +183,8 @@ def create_covar_matrix_newest(overlap_array,variances):
     overlap_array_padded[covarS:-covarS,covarS:-covarS,:] = overlap_array
     overlap_array = overlap_array_padded
 
-    xA = np.arange(sx, dtype=np.int)
-    yA = np.arange(sy, dtype=np.int)
+    xA = np.arange(sx, dtype=int)
+    yA = np.arange(sy, dtype=int)
 
     xC = xA[:, None, None, None] + covarS + xB[None, None, :, :]
     yC = yA[None, :, None, None] + covarS + yB[None, None, :, :]
@@ -199,7 +199,7 @@ def create_covar_matrix_newest(overlap_array,variances):
     #a[to_be_processed][np.where(~np.isfinite(a[to_be_processed]))] = 1.0
     a[np.where(~np.isfinite(a))] = 1.0 # This new.
 
-    fake_ax = np.arange(len(variances), dtype=np.int)
+    fake_ax = np.arange(len(variances), dtype=int)
 
     #b = overlap_array[xC[:, :, None, :, :], yC[:, :, None, :, :], fake_ax[None, None, :, None, None]] * np.sqrt(variances[None, None, :, None, None]) # 50 x 50 x 427 x 25
     b = overlap_array[xC[:, :, None, :, :], yC[:, :, None, :, :], fake_ax[None, None, :, None, None]][t2[0], t2[1], :, :, :] * np.sqrt(variances[None, None, :, None, None]) # 50 x 50 x 427 x 25

--- a/general/cubing.py
+++ b/general/cubing.py
@@ -506,7 +506,7 @@ def dithered_cubes_from_rss_files(inlist, **kwargs):
         cols=line.split(' ')
         cols[0]=str.strip(cols[0])
 
-        files.append(np.str(cols[0]))
+        files.append(str(cols[0]))
 
     dithered_cubes_from_rss_list(files, **kwargs)
     return
@@ -1613,13 +1613,13 @@ def create_metadata_table(ifu_list):
             columns.append(pf.Column(
                 name=keyword,
                 format='L',
-                array=get_primary_header_values(keyword,np.bool)
+                array=get_primary_header_values(keyword,bool)
                 )) 
         elif (isinstance(first_header[keyword],int)):
             columns.append(pf.Column(
                 name=keyword,
                 format='K',
-                array=get_primary_header_values(keyword,np.int)
+                array=get_primary_header_values(keyword,int)
                 )) # 64-bit integer
         elif (isinstance(first_header[keyword],str)):
             columns.append(pf.Column(
@@ -1631,7 +1631,7 @@ def create_metadata_table(ifu_list):
             columns.append(pf.Column(
                 name=keyword,
                 format='E',
-                array=get_primary_header_values(keyword,np.float)
+                array=get_primary_header_values(keyword,float)  # float removed in numpy 1.24
                 )) # single-precision float
 
     del get_primary_header_values

--- a/general/display.py
+++ b/general/display.py
@@ -145,7 +145,7 @@ def display_list(inlist, ifu, log=True):
         cols=line.split(' ')
         cols[0]=str.strip(cols[0])
         
-        files.append(np.str(cols[0]))
+        files.append(str(cols[0]))
 
     # Number of files 
     n=len(files)
@@ -422,7 +422,7 @@ def raw(flat_file, object_file, IFU="unknown", sigma_clip=False, log=True,
 
     # Range to find spatial cut
     if pix_start != "unknown":
-        cut_loc_start = np.float(pix_start+5)/np.float(2048)
+        cut_loc_start = float(pix_start+5)/float(2048)
         cut_locs = np.linspace(cut_loc_start,0.75,201)
     else:
         cut_locs = np.linspace(0.25,0.75,201)
@@ -682,7 +682,7 @@ def raw2(flat_file, object_file, IFU="unknown", sigma_clip=False, log=True,
 
     # Range to find spatial cut
     if pix_start != "unknown":
-        cut_loc_start = np.float(pix_start+5)/np.float(2048)
+        cut_loc_start = float(pix_start+5)/float(2048)
         cut_locs = np.linspace(cut_loc_start,0.75,201)
     else:
         cut_locs = np.linspace(0.25,0.75,201)

--- a/manager.py
+++ b/manager.py
@@ -6862,7 +6862,7 @@ def read_hector_tiles(abs_root=None):
         # Check to see if the number of columns and their names match by comparing the headers
         ss_header = pd.read_csv(f"{base_path}/{file_names[1]}", nrows=0).columns
         for abs_path in not_in_list:
-            print(abs_path)
+            log.debug(abs_path)  # was a bare print() flooding stdout every fluxcal_secondary iter
             pd.read_csv(abs_path, nrows=0, header=11).columns
         cols = [pd.read_csv(abs_path, nrows=0, header=11).columns for abs_path in not_in_list]
         cols_identical = [all(ss_header == colx) for colx in cols]
@@ -6889,7 +6889,7 @@ def read_hector_tiles(abs_root=None):
                 print(afile+' does not have run stamp. Read secondary from default H, U bundles')
                 run_start_epoch=0
 
-            print(afile, run_start_epoch)
+            log.debug("%s %s", afile, run_start_epoch)  # was a bare print() flooding stdout
             if run_start_epoch > 2025.5 and run_start_epoch < 2025.75:
 #            if (int(year) >= 2025) & (int(month)>=7) & (int(month)<10):
                 hector_tile.loc[["G", "U"]].to_csv(f"{base_path}/{file_names[1]}", mode='a', header=False, index=False)

--- a/observing/centroid.py
+++ b/observing/centroid.py
@@ -360,7 +360,7 @@ def focus(inlist, ifu):
         cols=line.split()
         cols[0]=str.strip(cols[0])
         
-        files.append(np.str(cols[0]))
+        files.append(str(cols[0]))
 
     # Number of files 
     n=len(files)
@@ -627,6 +627,9 @@ def centroid_fit(x,y,data,reference=None,rssframe=None,galaxyid=None,microns=Tru
     working_dir = rssframe.strip('sci.fits')
 
     # Smooth the data spectrally to get rid of cosmics
+    # Cast to native float64 — FITS data is big-endian (>f4), which scipy >= 1.13's
+    # median_filter rejects with "Unsupported array type".
+    data = np.ascontiguousarray(data, dtype=np.float64)
     data_smooth=np.zeros_like(data)
     for q in range(np.shape(data)[0]):
         # data_smooth[q,:]=utils.smooth(data[q,:], 11) #default hanning smooth

--- a/observing/sn.py
+++ b/observing/sn.py
@@ -88,7 +88,7 @@ def sn_list(inlist, tablein, l1, l2, ifus='all'):
         cols=line.split(' ')
         cols[0]=str.strip(cols[0])
         
-        files.append(np.str(cols[0]))
+        files.append(str(cols[0]))
 
     print("I have received", len(files), \
         "files for which to calculate and combine S/N measurements.")
@@ -459,7 +459,7 @@ def sn_re(insami, tablein, l1, l2, plot=False, ifus='all',
 
             # Write images
             if output: 
-                outsnfile='sn_'+np.str(l1)+'_'+np.str(l2)+'_'+\
+                outsnfile='sn_'+str(l1)+'_'+str(l2)+'_'+\
                     str(ifu_num)+'_'+insami
                 pf.writeto(outsnfile, np.transpose(frame), clobber=True)
             


### PR DESCRIPTION
Three compatibility fixes that let the pipeline run on a current scientific-Python
stack (NumPy >= 1.24, SciPy >= 1.13), plus a log-noise cleanup. All changes are
mechanical / compatibility-only — **no change to scientific behaviour**.

## A — Replace NumPy aliases removed in 1.24
`np.float` / `np.int` / `np.bool` / `np.str` were deprecated in NumPy 1.20 and
**removed in 1.24**, so several modules raise `AttributeError` on any current numpy.
Replaced with the builtin `float`/`int`/`bool`/`str` (exact equivalents for these
scalar uses): `dr/binning.py`, `dr/cvd_model.py`, `dr/voronoi_2d_binning_wcovar.py`,
`general/covar.py`, `general/cubing.py`, `general/display.py`, `observing/sn.py`,
`observing/centroid.py`.

## B — SciPy >= 1.13 big-endian fix (`observing/centroid.py`)
`scipy.ndimage.median_filter` in SciPy >= 1.13 rejects non-native byte order. Hector
FITS data is big-endian (`>f4`), so `measure_offsets` crashed with *"Unsupported
array type"*. `centroid_fit` now casts to a native contiguous `float64` array first.

## C — Log-noise cleanup (`manager.py`)
Two bare `print()` calls in `read_hector_tiles()` fired for every tile file on every
`fluxcal_secondary` iteration (~100k lines per run). Routed through the existing
module logger at `DEBUG` level.

### Notes
- No functional/scientific change; all touched files still import cleanly.
- Validated by a full end-to-end reduction (G15 tile + an FRB ToO field) on
  macOS / Python 3.11 / numpy 1.x / scipy >= 1.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
